### PR TITLE
修复#3

### DIFF
--- a/src/main/java/top/gcszhn/autocard/service/MailService.java
+++ b/src/main/java/top/gcszhn/autocard/service/MailService.java
@@ -82,6 +82,8 @@ public class MailService implements AppService {
         if (smtpPort!=null) {
             props.setProperty("mail.smtp.port", smtpPort);
         }
+        props.put("mail.smtp.starttls.required", "true");
+        props.put("mail.smtp.ssl.protocols", "TLSv1.2");
         if (username==null|password==null) {
             LogUtils.printMessage("Mail user not set");
             setServiceAvailable(false);


### PR DESCRIPTION
openJDK默认不启用TLS 1.X，通过启用而修复相关问题#3.